### PR TITLE
Remove Widget Title from array

### DIFF
--- a/includes/class-arconix-testimonials-widgets.php
+++ b/includes/class-arconix-testimonials-widgets.php
@@ -68,8 +68,11 @@ class Arconix_Testimonials_Widget extends WP_Widget {
         echo $before_widget;
 
         // Title of widget (before and after defined by themes).
-        if ( !empty( $instance['title'] ) )
+        if( ! empty( $instance['title'] ) )
             echo $before_title . apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base ) . $after_title;
+
+        // Don't send the widget title through to the loop (causes problems)
+        unset( $instance['title'] );
 
         $t = new Arconix_Testimonial();
         $t->loop( $instance, true );


### PR DESCRIPTION
Previously, when supplying a widget title the testimonial loop would
fail and return no results. When the title is blank behavior was as
expected. Unsetting the widget title from the array resolved the issue.

Fixes #17